### PR TITLE
Fix Windows bug for pom name with space.

### DIFF
--- a/src/main/groovy/org/codehaus/mojo/codenarc/CodeNarcMojo.groovy
+++ b/src/main/groovy/org/codehaus/mojo/codenarc/CodeNarcMojo.groovy
@@ -1,4 +1,3 @@
-
 package org.codehaus.mojo.codenarc
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -367,7 +366,7 @@ log4j.appender.CONSOLE.layout.ConversionPattern=%d{ISO8601} %c{1} [%t] %p - %m%n
             log.debug( "antBasedir => ${antBasedir}")
             arg(value: antBasedir)
 
-            def antTitle='-title="' + this.project.name + '"'
+            def antTitle="-title='" + this.project.name + "'"
             log.debug( "antTitle => ${antTitle}" )
             arg(value: antTitle)
 


### PR DESCRIPTION
In Windows if there is a space in the pom.xml's name it causes the plugin to fail to generate a report xml. The single-line patch fixes the bug for Windows and it continues to work on Unix systems.

Including the codenarc-maven-plugin in a pom with spaces in the name (e.g. <name>Test Name</name>) will generate the following error:

```
[INFO] sourceDirectory is C:\Users\xxxxx\test\src\main\groovy
     [java] ERROR: Invalid argument format: [Name]. Expression: matcher. Values: matcher = java.util.regex.Matcher[pattern=\-(.*)\=(.*) region=0,4 lastmatch=]
     [java] java.lang.AssertionError: Invalid argument format: [Name]. Expression: matcher. Values: matcher = java.util.regex.Matcher[pattern=\-(.*)\=(.*) region=0,4 lastmatch=]
     [java]     at org.codehaus.groovy.runtime.InvokerHelper.assertFailed(InvokerHelper.java:401)
     [java]     at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.assertFailed(ScriptBytecodeAdapter.java:655)
     [java]     at org.codenarc.CodeNarc$_parseArgs_closure3.doCall(CodeNarc.groovy:153)
     [java]     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     [java]     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
     [java]     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
     [java]     at java.lang.reflect.Method.invoke(Method.java:597)
     [java]     at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:90)
     [java]     at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:233)
     [java]     at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:272)
     [java]     at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:906)
     [java]     at groovy.lang.Closure.call(Closure.java:412)
     [java]     at groovy.lang.Closure.call(Closure.java:425)
     [java]     at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:1326)
     [java]     at org.codehaus.groovy.runtime.DefaultGroovyMethods.each(DefaultGroovyMethods.java:1298)
     [java]     at org.codehaus.groovy.runtime.dgm$148.invoke(Unknown Source)
     [java]     at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite$PojoMetaMethodSiteNoUnwrapNoCoerce.invoke(PojoMetaMethodSite.java:271)
     [java]     at org.codehaus.groovy.runtime.callsite.PojoMetaMethodSite.call(PojoMetaMethodSite.java:53)
     [java]     at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
     [java]     at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
     [java]     at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
     [java]     at org.codenarc.CodeNarc.parseArgs(CodeNarc.groovy:150)
     [java]     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     [java]     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
     [java]     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
     [java]     at java.lang.reflect.Method.invoke(Method.java:597)
     [java]     at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:272)
     [java]     at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.callCurrent(PogoMetaMethodSite.java:52)
     [java]     at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallCurrent(CallSiteArray.java:49)
     [java]     at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:133)
     [java]     at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callCurrent(AbstractCallSite.java:141)
     [java]     at org.codenarc.CodeNarc.execute(CodeNarc.groovy:119)
     [java]     at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
     [java]     at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
     [java]     at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
     [java]     at java.lang.reflect.Method.invoke(Method.java:597)
     [java]     at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite$PogoCachedMethodSiteNoUnwrapNoCoerce.invoke(PogoMetaMethodSite.java:272)
     [java] CodeNarc - static analysis for Groovy',
     [java]     at org.codehaus.groovy.runtime.callsite.PogoMetaMethodSite.call(PogoMetaMethodSite.java:64)
     [java] Usage: java org.codenarc.CodeNarc [OPTIONS]
     [java]     at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:45)
     [java]   where OPTIONS are zero or more command-line options of the form "-NAME[=VALUE]":
     [java]     at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:108)
     [java]     at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:116)
     [java]     -basedir=<DIR>
     [java]     at org.codenarc.CodeNarc.main(CodeNarc.groovy:109)
     [java]         The base (root) directory for the source code to be analyzed.
     [java]         Defaults to the current directory (".").
     [java]     -includes=<PATTERNS>
     [java]         The comma-separated list of Ant-style file patterns specifying files that must
     [java]         be included. Defaults to "**/*.groovy".
     [java]     -excludes=<PATTERNS>
     [java]         The comma-separated list of Ant-style file patterns specifying files that must
     [java]         be excluded. No files are excluded when omitted.
     [java]     -rulesetfiles=<FILENAMES>
     [java]         The path to the Groovy or XML RuleSet definition files, relative to the classpath.
     [java]         This can be a single file path, or multiple paths separated by commas.
     [java]         Defaults to "rulesets/basic.xml"
     [java]     -title=<REPORT TITLE>
     [java]         The title descriptive for this analysis; used in the output report(s). Optional.
     [java]     -report=<REPORT-TYPE[:FILENAME]>
     [java]         The definition of the report to produce. The option value is of the form
     [java]         TYPE[:FILENAME], where TYPE is "html", "text", "xml", or "console" and FILENAME is the filename (with
     [java]         optional path) of the output report filename. If the report filename is
     [java]         omitted, the default filename is used for the specified report type
     [java]         ("CodeNarcReport.html" for "html" and "CodeNarcXmlReport.xml" for "xml"). If no
     [java]         report option is specified, default to a single "html" report with the
     [java]         default filename.
     [java]     -help
     [java]         Display the command-line help. If present, this must be the only command-line parameter.
     [java]   Example command-line invocations:
     [java]     java org.codenarc.CodeNarc
     [java]     java org.codenarc.CodeNarc -rulesetfiles="rulesets/basic.xml" title="My Project"
     [java]     java org.codenarc.CodeNarc -report=xml:MyXmlReport.xml -report=html
     [java]     java org.codenarc.CodeNarc -help'
[INFO] Generating CodeNarc HTML
[INFO] Reporter Locale is
[INFO] totalPriority1Violations is 0
[INFO] totalPriority2Violations is 0
[INFO] totalPriority3Violations is 0 
```
